### PR TITLE
Fix blog delete for attached BlogId in Post

### DIFF
--- a/TabloidCLI/Repositories/BlogRepository.cs
+++ b/TabloidCLI/Repositories/BlogRepository.cs
@@ -139,9 +139,9 @@ namespace TabloidCLI.Repositories
                 conn.Open();
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = @"DELETE FROM Blog WHERE id = @id";
+                    cmd.CommandText = @"DELETE FROM Post WHERE BlogId = @id;
+                                        DELETE FROM Blog WHERE id = @id";
                     cmd.Parameters.AddWithValue("@id", id);
-
                     cmd.ExecuteNonQuery();
                 }
             }

--- a/TabloidCLI/UserInterfaceManagers/BlogManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/BlogManager.cs
@@ -159,10 +159,16 @@ namespace TabloidCLI.UserInterfaceManagers
 
     private void Remove()
     {
-        Blog blogToDelete = Choose("Which author would you like to remove?");
+        Blog blogToDelete = Choose("Which blog would you like to remove?");
         if (blogToDelete != null)
         {
-            _blogRepository.Delete(blogToDelete.Id);
+            Console.WriteLine("If any Posts contain this blog, they will be deleted as well.");
+            Console.Write("Type 'y' or 'yes' to confirm: ");
+            string confirmDelete = Console.ReadLine().ToLower();
+            if (confirmDelete == "y" || confirmDelete == "yes")
+            {
+                _blogRepository.Delete(blogToDelete.Id);
+            }
         }
     }
 }

--- a/TabloidCLI/UserInterfaceManagers/PostManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostManager.cs
@@ -76,7 +76,8 @@ namespace TabloidCLI.UserInterfaceManagers
                 Console.WriteLine(post.Title);
             }
             Console.WriteLine("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
-            Console.ReadLine();
+            Console.WriteLine("\nPress any key to continue...");
+            Console.ReadKey();
             Console.Clear();
         }
         private void Add()


### PR DESCRIPTION
# Description
This fixes a bug where, when a Blog is to be deleted, the app would crash if any posts have that same BlogId associated. Now, the user is asked to confirm deleting any attached posts. Then, those posts are deleted, followed by the blog itself. Same applies to any tags attached to blogs, and vice versa.
Fixes # no ticket
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
# Testing Instructions
Run the program. Make sure a blog exists that is to-be-deleted, and make sure a post exists that references that same blog. Then, delete the blog. To confirm successful deletion, view the blog list and the post list.
To test for tags, make sure a tag is attached to a blog.  Then, delete the blog or the tag. The blog will ask for confirmation. The tag will not, since it uses a separate join table. Deletions should be successful.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
