### PR TITLE
Fix BlogTag deletion from Tag delete and Blog delete

### DIFF
--- a/TabloidCLI/Repositories/BlogRepository.cs
+++ b/TabloidCLI/Repositories/BlogRepository.cs
@@ -140,6 +140,7 @@ namespace TabloidCLI.Repositories
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"DELETE FROM Post WHERE BlogId = @id;
+                                        DELETE FROM BlogTag WHERE BlogId = @id;
                                         DELETE FROM Blog WHERE id = @id";
                     cmd.Parameters.AddWithValue("@id", id);
                     cmd.ExecuteNonQuery();

--- a/TabloidCLI/Repositories/TagRepository.cs
+++ b/TabloidCLI/Repositories/TagRepository.cs
@@ -121,7 +121,8 @@ namespace TabloidCLI
                 conn.Open();
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = @"DELETE FROM Tag WHERE id = @id";
+                    cmd.CommandText = @"DELETE FROM BlogTag WHERE TagId = @id;
+                                        DELETE FROM Tag WHERE id = @id";
                     cmd.Parameters.AddWithValue("@id", id);
 
                     cmd.ExecuteNonQuery();


### PR DESCRIPTION
# Description
NOTE: This is a duplicate of the previous PR, where the Tag updates did not push up.
This fixes a bug where, when a Blog is to be deleted, the app would crash if any posts have that same BlogId associated. Now, the user is asked to confirm deleting any attached posts. Then, those posts are deleted, followed by the blog itself. Same applies to any tags attached to blogs, and vice versa.
Fixes # no ticket
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
# Testing Instructions
Run the program. Make sure a blog exists that is to-be-deleted, and make sure a post exists that references that same blog. Then, delete the blog. To confirm successful deletion, view the blog list and the post list.
To test for tags, make sure a tag is attached to a blog.  Then, delete the blog or the tag. The blog will ask for confirmation. The tag will not, since it uses a separate join table. Deletions should be successful.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
