### PR TITLE
Blog and Post Field Len Checks for Title, TagRepos SQL Correction

### DIFF
--- a/TabloidCLI/Repositories/TagRepository.cs
+++ b/TabloidCLI/Repositories/TagRepository.cs
@@ -217,16 +217,16 @@ namespace TabloidCLI
                                                p.Title,
                                                p.URL,
                                                p.PublishDateTime,
-                                               Author.Id as AuthorId
+                                               Author.Id as AuthorId,
                                                Author.FirstName,
                                                Author.LastName,
                                                Author.Bio,
                                                Blog.Id as BlogId,
                                                Blog.Title as BlogTitle,
-                                               Blog.URL as BlogUrl,
+                                               Blog.URL as BlogUrl
                                           FROM Post p
-                                               LEFT JOIN Author on Author.Id = Post.AuthorId
-                                               LEFT JOIN Blog on Blog.Id = Post.BlogId
+                                               LEFT JOIN Author on Author.Id = p.AuthorId
+                                               LEFT JOIN Blog on Blog.Id = p.BlogId
                                                LEFT JOIN PostTag pt on p.Id = pt.PostId
                                                LEFT JOIN Tag t on t.Id = pt.TagId
                                          WHERE t.Name LIKE @name";

--- a/TabloidCLI/UserInterfaceManagers/BlogManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/BlogManager.cs
@@ -111,13 +111,15 @@ namespace TabloidCLI.UserInterfaceManagers
     {
         Console.WriteLine("New Blog");
         Blog blog = new Blog();
+            blog.Title = "";
         
         do
-        { 
+        {
+            if (blog.Title.Length > 55) { Console.WriteLine("The maximum title length is 55 characters. Please shorten the title."); }
             Console.Write("New Blog Title: ");
             blog.Title = Console.ReadLine();
             Console.Clear();
-        } while (blog.Title == "");
+        } while (blog.Title == "" || blog.Title.Length > 55 );
 
          do
          {

--- a/TabloidCLI/UserInterfaceManagers/BlogManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/BlogManager.cs
@@ -142,9 +142,17 @@ namespace TabloidCLI.UserInterfaceManagers
         }
 
         Console.WriteLine();
-        Console.Write("New first name (blank to leave unchanged): ");
-            string title = Console.ReadLine();
-        if (!string.IsNullOrWhiteSpace(title))
+            string title = "";
+        do
+        {
+            if (title.Length > 55) { Console.WriteLine("The maximum title length is 55 characters. Please shorten the title or hit ENTER to keep the same title."); }
+            Console.Write("New Blog Title: ");
+            title = Console.ReadLine();
+            Console.Clear();
+        } while (title.Length > 55);
+
+
+            if (!string.IsNullOrWhiteSpace(title))
         {
             blogToEdit.Title = title;
         }

--- a/TabloidCLI/UserInterfaceManagers/JournalManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/JournalManager.cs
@@ -102,12 +102,14 @@ namespace TabloidCLI.UserInterfaceManagers
         {
             Console.WriteLine("New Journal Entry");
             Journal journal = new Journal();
+            journal.Title = "";
             do
             {
+                if (journal.Title.Length > 55) { Console.WriteLine("The maximum title length is 55 characters. Please shorten the title."); }
                 Console.Write("New Journal Entry Title: ");
                 journal.Title = Console.ReadLine();
                 Console.Clear();
-            } while (journal.Title == "");
+            } while (journal.Title == "" || journal.Title.Length > 55);
 
             do
             {

--- a/TabloidCLI/UserInterfaceManagers/PostManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostManager.cs
@@ -85,12 +85,14 @@ namespace TabloidCLI.UserInterfaceManagers
 
             Console.WriteLine("New Post");
             Post post = new Post();
+            post.Title = "";
             do
             {
                 Console.Clear();
+                if (post.Title.Length > 55) { Console.WriteLine("The maximum title length is 55 characters. Please shorten the title."); }
                 Console.Write("Title: ");
                 post.Title = Console.ReadLine();
-            } while (post.Title == "");
+            } while (post.Title == "" || post.Title.Length > 55);
             
             do
             {

--- a/TabloidCLI/UserInterfaceManagers/PostManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostManager.cs
@@ -155,7 +155,14 @@ namespace TabloidCLI.UserInterfaceManagers
             //title,url,pubdate,author,blog
             Console.WriteLine();
             Console.Write("New Title (blank to leave unchanged) ");
-            string title = Console.ReadLine();
+            string title = "";
+            do
+            {
+                if (title.Length > 55) { Console.WriteLine("The maximum title length is 55 characters. Please shorten the title or hit ENTER to keep the same title."); }
+                Console.Write("New Post Title: ");
+                title = Console.ReadLine();
+                Console.Clear();
+            } while (title.Length > 55);
             if (!string.IsNullOrWhiteSpace(title))
             {
                 postToEdit.Title = title;


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Added title field length checks for Add/Edit Blog, Add/Edit Post, and a correction to TagRepository sql.
Fixes # (issue)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
Tag Search works without exceptions.

- [x] New feature (non-breaking change which adds functionality)
If Title entered is too long, a prompt will appear informing the user of the max field length.

# Testing Instructions
Please describe the tests required to verify your changes. Provide instructions so PR Tester can check functionality. Please also list any relevant details for your tests
1. From main menu, go to Blog Management, Add Blog, enter a title longer than 55 characters to get prompt.
2. From main menu, go to Post Management, Add Blog, enter a title longer than 55 characters to get prompt.
3. From main menu, go to Search by Tag, then Search All, to verify no exception occurs.


# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have added test instructions that prove my fix is effective or that my feature works
