### PR TITLE
Implement character limits on Author and Tag names

### DIFF
--- a/TabloidCLI/UserInterfaceManagers/AuthorManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/AuthorManager.cs
@@ -163,6 +163,7 @@ namespace TabloidCLI.UserInterfaceManagers
                 if (firstName.Length > 55) Console.WriteLine("Name cannot exceed 55 characters.");
                 Console.Write("New first name (blank to leave unchanged): ");
                 firstName = Console.ReadLine();
+                Console.Clear();
             } while (firstName.Length > 55);
             // If a blank is entered at any time, the value in the class remains unchanged
             if (!string.IsNullOrWhiteSpace(firstName))
@@ -176,6 +177,7 @@ namespace TabloidCLI.UserInterfaceManagers
                 if (lastName.Length > 55) Console.WriteLine("Name cannot exceed 55 characters.");
                 Console.Write("New last name (blank to leave unchanged): ");
                 lastName = Console.ReadLine();
+                Console.Clear();
             } while (lastName.Length > 55);
             // If a blank is entered at any time, the value in the class remains unchanged
             if (!string.IsNullOrWhiteSpace(lastName))

--- a/TabloidCLI/UserInterfaceManagers/AuthorManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/AuthorManager.cs
@@ -113,21 +113,29 @@ namespace TabloidCLI.UserInterfaceManagers
         private void Add()
         {
                 Console.WriteLine("New Author");
-                Author author = new Author();
+                // FirstName and LastName must be insantiated for character length checks during input
+                Author author = new Author()
+                {
+                    FirstName = "",
+                    LastName = ""
+                };
 
+            // FirstName and LastName have a 55 character limit in the database
             do
-            { 
+            {
+                if (author.FirstName.Length > 55) Console.WriteLine("Name cannot exceed 55 characters.");
                 Console.Write("New Author First Name: ");
                 author.FirstName = Console.ReadLine();
                 Console.Clear();
-            } while (author.FirstName == "");
+            } while (author.FirstName == "" | author.FirstName.Length > 55);
 
             do
             {
+                if (author.LastName.Length > 55) Console.WriteLine("Name cannot exceed 55 characters.");
                 Console.Write("New Author Last Name: ");
                 author.LastName = Console.ReadLine();
                 Console.Clear();
-            } while (author.LastName == "");
+            } while (author.LastName == "" | author.LastName.Length > 55);
 
             do
             {
@@ -147,19 +155,34 @@ namespace TabloidCLI.UserInterfaceManagers
                 return;
             }
 
+            // FirstName and LastName have a 55 character limit in the database
             Console.WriteLine();
-            Console.Write("New first name (blank to leave unchanged): ");
-            string firstName = Console.ReadLine();
+            string firstName = "";
+            do
+            {
+                if (firstName.Length > 55) Console.WriteLine("Name cannot exceed 55 characters.");
+                Console.Write("New first name (blank to leave unchanged): ");
+                firstName = Console.ReadLine();
+            } while (firstName.Length > 55);
+            // If a blank is entered at any time, the value in the class remains unchanged
             if (!string.IsNullOrWhiteSpace(firstName))
             {
                 authorToEdit.FirstName = firstName;
             }
-            Console.Write("New last name (blank to leave unchanged): ");
-            string lastName = Console.ReadLine();
+
+            string lastName = "";
+            do
+            {
+                if (lastName.Length > 55) Console.WriteLine("Name cannot exceed 55 characters.");
+                Console.Write("New last name (blank to leave unchanged): ");
+                lastName = Console.ReadLine();
+            } while (lastName.Length > 55);
+            // If a blank is entered at any time, the value in the class remains unchanged
             if (!string.IsNullOrWhiteSpace(lastName))
             {
                 authorToEdit.LastName = lastName;
             }
+
             Console.Write("New bio (blank to leave unchanged): ");
             string bio = Console.ReadLine();
             if (!string.IsNullOrWhiteSpace(bio))

--- a/TabloidCLI/UserInterfaceManagers/TagManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/TagManager.cs
@@ -97,9 +97,16 @@ namespace TabloidCLI.UserInterfaceManagers
 
         private void Add()
         {
-            Console.WriteLine("Let's add a Tag...");
-            Console.WriteLine("What is the Tag Name?  (ENTER to cancel)");
-            string tagName = Console.ReadLine();
+            string tagName = "";
+            do
+            {
+                if (tagName.Length > 55) Console.WriteLine("Name cannot be longer than 55 characters.");
+                Console.WriteLine("Let's add a Tag...");
+                Console.WriteLine("What is the Tag Name?  (ENTER to cancel)");
+                tagName = Console.ReadLine();
+                Console.Clear();
+            } while (tagName.Length > 55);
+
             if (tagName != "")
             {
                 Tag tag = new Tag { Name = tagName };
@@ -117,10 +124,16 @@ namespace TabloidCLI.UserInterfaceManagers
             {
                 return;
             }
-
+            
+            string name = "";
             Console.WriteLine();
-            Console.Write("New name (blank to leave unchanged: ");
-            string name = Console.ReadLine();
+            do
+            {
+                if (name.Length > 55) Console.WriteLine("Name cannot be longer than 55 characters.");
+                Console.Write("New name (blank to leave unchanged): ");
+                name = Console.ReadLine();
+                Console.Clear();
+            } while (name.Length > 55);
             if (!string.IsNullOrWhiteSpace(name))
             {
                 tagToEdit.Name = name;


### PR DESCRIPTION
# Description
Implemented a 55 character limit on Author FirstName and LastName and Tag names to match limits of the database. This applies to new and edited objects.
If there is time, we may be able to refactor some of these changes to further meet DRY principles.

Fixes # no tickets
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
# Testing Instructions
Run the program. When adding or editing a new author, try typing an excessively long First Name and Last Name. The program should reprompt for that value. Do the same with a Tag name. Note: the author Bio does not have a character limit in the database, so the program also has no character limit.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
