### PR TITLE
Add 'coming soon' to unimplemented menu options

### DIFF
--- a/TabloidCLI/UserInterfaceManagers/AuthorManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/AuthorManager.cs
@@ -43,6 +43,9 @@ namespace TabloidCLI.UserInterfaceManagers
                     List();
                     return this;
                 case "2":
+                    Console.WriteLine("This feature is coming soon!");
+                    return this;
+                    /* Future code to be implemented
                     Author author = Choose();
                     if (author == null)
                     {
@@ -52,6 +55,7 @@ namespace TabloidCLI.UserInterfaceManagers
                     {
                         return new AuthorDetailManager(this, _connectionString, author.Id);
                     }
+                    */ 
                 case "3":
                     Add();
                     return this;

--- a/TabloidCLI/UserInterfaceManagers/PostManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostManager.cs
@@ -41,15 +41,19 @@ namespace TabloidCLI.UserInterfaceManagers
                     List();
                     return this;
                 case "2":
-                    Post post = Choose();
-                    if (post == null)
-                    {
-                        return this;
-                    }
-                    else
-                    {
-                        return new AuthorDetailManager(this, _connectionString, post.Id);
-                    }
+                    Console.WriteLine("This feature is coming soon!");
+                    return this;
+                /* Future code to be implemented
+                Post post = Choose();
+                if (post == null)
+                {
+                return this;
+                }
+                else
+                {
+                return new AuthorDetailManager(this, _connectionString, post.Id);
+                }
+                */
                 case "3":
                     Add();
                     return this;


### PR DESCRIPTION
# Description
Added a "Coming soon" message and rerouted to the parent menu for menu options that are unimplemented.
Partial code for these features is commented out.
Fixes # no tickets
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
In the program, navigate to Author management, and try to go to "Author details." Within Post Management, try to navigate to "Post details." Both should reroute to their respective management menus and return a message.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
