### PR TITLE
Change author menu to allow tags but disallow viewing blog posts

### DIFF
--- a/TabloidCLI/UserInterfaceManagers/AuthorDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/AuthorDetailManager.cs
@@ -41,7 +41,10 @@ namespace TabloidCLI.UserInterfaceManagers
                     View();
                     return this;
                 case "2":
+                    Console.WriteLine("This feature is coming soon!");
+                    /* Future code to be implemented
                     ViewBlogPosts();
+                    */
                     return this;
                 case "3":
                     AddTag();

--- a/TabloidCLI/UserInterfaceManagers/AuthorManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/AuthorManager.cs
@@ -43,9 +43,6 @@ namespace TabloidCLI.UserInterfaceManagers
                     List();
                     return this;
                 case "2":
-                    Console.WriteLine("This feature is coming soon!");
-                    return this;
-                    /* Future code to be implemented
                     Author author = Choose();
                     if (author == null)
                     {
@@ -55,7 +52,6 @@ namespace TabloidCLI.UserInterfaceManagers
                     {
                         return new AuthorDetailManager(this, _connectionString, author.Id);
                     }
-                    */ 
                 case "3":
                     Add();
                     return this;


### PR DESCRIPTION
# Description
The last PR prevents author tags from being accessible. Refactored the author menu so that most of the Author Details submenu is accessible, but only the unimplemented "Author Blog Posts" item is inaccessible.
Fixes # no tickets
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
# Testing Instructions
Run the program. Within the Author Management menu, go to Author Details. Make sure all options work except "View blog posts," which should return a "coming soon" message.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
